### PR TITLE
Convert headers keys to lowercase

### DIFF
--- a/src/Inertia.php
+++ b/src/Inertia.php
@@ -71,7 +71,7 @@ class Inertia
 
         self::$request = array_merge([
             'WP-Inertia' => (array) $wp,
-        ], getallheaders());
+        ], InertiaHeaders::all());
     }
 
     protected static function setUrl()
@@ -85,14 +85,14 @@ class Inertia
     {
         $props = array_merge($props, self::$shared_props);
 
-        $partial_data = isset(self::$request['X-Inertia-Partial-Data'])
-            ? self::$request['X-Inertia-Partial-Data']
+        $partial_data = isset(self::$request['x-inertia-partial-data'])
+            ? self::$request['x-inertia-partial-data']
             : null;
 
         $only = array_filter(explode(',', $partial_data));
 
-        $partial_component = isset(self::$request['X-Inertia-Partial-Component'])
-            ? self::$request['X-Inertia-Partial-Component']
+        $partial_component = isset(self::$request['x-inertia-partial-component'])
+            ? self::$request['x-inertia-partial-component']
             : null;
 
         $props = ($only && $partial_component === self::$component)

--- a/src/InertiaHeaders.php
+++ b/src/InertiaHeaders.php
@@ -4,9 +4,14 @@ namespace BoxyBird\Inertia;
 
 class InertiaHeaders
 {
+    public static function all()
+    {
+        return array_change_key_case(getallheaders(), CASE_LOWER);
+    }
+
     public static function inRequest()
     {
-        $headers = array_change_key_case(getallheaders(), CASE_LOWER);
+        $headers = self::all();
 
         if (isset($headers['x-requested-with'])
             && $headers['x-requested-with'] === 'XMLHttpRequest'

--- a/src/InertiaHeaders.php
+++ b/src/InertiaHeaders.php
@@ -6,12 +6,12 @@ class InertiaHeaders
 {
     public static function inRequest()
     {
-        $headers = getallheaders();
+        $headers = array_change_key_case(getallheaders(), CASE_LOWER);
 
-        if (isset($headers['X-Requested-With'])
-            && $headers['X-Requested-With'] === 'XMLHttpRequest'
-            && isset($headers['X-Inertia'])
-            && $headers['X-Inertia'] === 'true'
+        if (isset($headers['x-requested-with'])
+            && $headers['x-requested-with'] === 'XMLHttpRequest'
+            && isset($headers['x-inertia'])
+            && $headers['x-inertia'] === 'true'
         ) {
             return true;
         }


### PR DESCRIPTION
When under a dns proxy like cloudflare, [all headers keys are converted to lowercase](https://community.cloudflare.com/t/how-to-enable-upper-case-at-response-headers/33960). Since in PHP array keys are case sensitive, the targetted headers  `X-Requested-With` and `X-Inertia`  in `InertiaHeaders::inRequest()`  both return `null` under cloudflare proxy.

Converting all the headers to lowercase then checking for lowercase keys fixes this issues.