### PR TITLE
Add lazy props support

### DIFF
--- a/src/LazyProp.php
+++ b/src/LazyProp.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace BoxyBird\Inertia;
+
+class LazyProp
+{
+    protected $callback;
+
+    public function __construct(callable $callback)
+    {
+        $this->callback = $callback;
+    }
+
+    public function __invoke()
+    {
+        return call_user_func($this->callback);
+    }
+}


### PR DESCRIPTION
Closes #14 

Following the `inertia-laravel` implementation, lazy props won't be included in the initial render but will be included when specifically requested in partial reloads.

```php
<?php

use BoxyBird\Inertia\Inertia;

return Inertia::render('Index', [
    'lazy_prop' => Inertia::lazy(function() {
        return 'lazy data';
    }),
]);
```

It's a headstart, will require a readme update and some testing. I might be able to provide this later.