### PR TITLE
Add support for `composer/installers`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,7 @@
 {
   "name": "boxybird/inertia-wordpress",
   "description": "The WordPress adapter for Inertia.js",
+  "type": "wordpress-plugin",
   "license": "MIT",
   "keywords": [
     "wordpress",


### PR DESCRIPTION
Allows automatic installation into `plugins` directory via [Composer Installer](https://github.com/composer/installers)